### PR TITLE
Fix trade to work properly with non stacking items

### DIFF
--- a/runelite-client/src/main/java/net/unethicalite/api/items/Trade.java
+++ b/runelite-client/src/main/java/net/unethicalite/api/items/Trade.java
@@ -130,7 +130,7 @@ public class Trade
 				item.interact("Offer-10");
 				break;
 			default:
-				if (quantity > item.getQuantity())
+				if (quantity > Inventory.getCount(true, item.getId()))
 				{
 					item.interact("Offer-All");
 				}


### PR DESCRIPTION
non stackable items (i.e. pure essence) does not work properly with the current item.getQuantity() check, needs to check for the amount in the inventory to get the correct count.