### PR TITLE
fix eighth spelling

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/MenuAction.java
+++ b/runelite-api/src/main/java/net/runelite/api/MenuAction.java
@@ -231,11 +231,7 @@ public enum MenuAction
 	PLAYER_FIFTH_OPTION(48),
 	PLAYER_SIXTH_OPTION(49),
 	PLAYER_SEVENTH_OPTION(50),
-	/**
-	 * @deprecated Replace EIGTH with correct spelling EIGHTH
-	 */
-	@Deprecated(since = "RuneLite API 1.9.3")
-	PLAYER_EIGTH_OPTION(51),
+	PLAYER_EIGHTH_OPTION(51),
 
 	/**
 	 * Menu action for normal priority child component actions.
@@ -318,6 +314,9 @@ public enum MenuAction
 	UNKNOWN(-1);
 
 	public static final int MENU_ACTION_DEPRIORITIZE_OFFSET = 2000;
+
+	@Deprecated
+	public static final MenuAction PLAYER_EIGTH_OPTION = MenuAction.PLAYER_EIGHTH_OPTION;
 
 	private static final Map<Integer, MenuAction> map = new HashMap<>();
 

--- a/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/playerindicators/PlayerIndicatorsPlugin.java
@@ -33,7 +33,7 @@ import net.runelite.api.FriendsChatRank;
 import static net.runelite.api.FriendsChatRank.UNRANKED;
 import net.runelite.api.MenuAction;
 import static net.runelite.api.MenuAction.ITEM_USE_ON_PLAYER;
-import static net.runelite.api.MenuAction.PLAYER_EIGTH_OPTION;
+import static net.runelite.api.MenuAction.PLAYER_EIGHTH_OPTION;
 import static net.runelite.api.MenuAction.PLAYER_FIFTH_OPTION;
 import static net.runelite.api.MenuAction.PLAYER_FIRST_OPTION;
 import static net.runelite.api.MenuAction.PLAYER_FOURTH_OPTION;
@@ -147,7 +147,7 @@ public class PlayerIndicatorsPlugin extends Plugin
 				|| type == PLAYER_FIFTH_OPTION
 				|| type == PLAYER_SIXTH_OPTION
 				|| type == PLAYER_SEVENTH_OPTION
-				|| type == PLAYER_EIGTH_OPTION
+				|| type == PLAYER_EIGHTH_OPTION
 				|| type == RUNELITE_PLAYER)
 			{
 				Player[] players = client.getCachedPlayers();

--- a/runelite-client/src/main/java/net/unethicalite/api/entities/Entities.java
+++ b/runelite-client/src/main/java/net/unethicalite/api/entities/Entities.java
@@ -118,7 +118,7 @@ public abstract class Entities<T extends SceneEntity>
 				case PLAYER_FIFTH_OPTION:
 				case PLAYER_SIXTH_OPTION:
 				case PLAYER_SEVENTH_OPTION:
-				case PLAYER_EIGTH_OPTION:
+				case PLAYER_EIGHTH_OPTION:
 				{
 					out.add(Static.getClient().getCachedPlayers()[menuEntry.getIdentifier()]);
 					break;

--- a/runelite-client/src/main/java/net/unethicalite/api/packets/Packets.java
+++ b/runelite-client/src/main/java/net/unethicalite/api/packets/Packets.java
@@ -111,7 +111,7 @@ public class Packets
 				return PlayerPackets.createSixthAction(id, false);
 			case PLAYER_SEVENTH_OPTION:
 				return PlayerPackets.createSeventhAction(id, false);
-			case PLAYER_EIGTH_OPTION:
+			case PLAYER_EIGHTH_OPTION:
 				return PlayerPackets.createEighthAction(id, false);
 			case ITEM_USE_ON_GROUND_ITEM:
 			case WIDGET_TARGET_ON_GROUND_ITEM:

--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -173,7 +173,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import static net.runelite.api.MenuAction.PLAYER_EIGTH_OPTION;
+import static net.runelite.api.MenuAction.PLAYER_EIGHTH_OPTION;
 import static net.runelite.api.MenuAction.PLAYER_FIFTH_OPTION;
 import static net.runelite.api.MenuAction.PLAYER_FIRST_OPTION;
 import static net.runelite.api.MenuAction.PLAYER_FOURTH_OPTION;
@@ -1401,7 +1401,7 @@ public abstract class RSClientMixin implements RSClient
 	{
 		// Reset the menu opcode
 		MenuAction[] playerActions = {PLAYER_FIRST_OPTION, PLAYER_SECOND_OPTION, PLAYER_THIRD_OPTION, PLAYER_FOURTH_OPTION,
-				PLAYER_FIFTH_OPTION, PLAYER_SIXTH_OPTION, PLAYER_SEVENTH_OPTION, PLAYER_EIGTH_OPTION};
+				PLAYER_FIFTH_OPTION, PLAYER_SIXTH_OPTION, PLAYER_SEVENTH_OPTION, PLAYER_EIGHTH_OPTION};
 		if (idx >= 0 && idx < playerActions.length)
 		{
 			MenuAction playerAction = playerActions[idx];

--- a/runelite-mixins/src/main/java/net/unethicalite/mixins/HPlayerMixin.java
+++ b/runelite-mixins/src/main/java/net/unethicalite/mixins/HPlayerMixin.java
@@ -53,7 +53,7 @@ public abstract class HPlayerMixin extends RSPlayerMixin implements RSPlayer
 			case 6:
 				return MenuAction.PLAYER_SEVENTH_OPTION.getId();
 			case 7:
-				return MenuAction.PLAYER_EIGTH_OPTION.getId();
+				return MenuAction.PLAYER_EIGHTH_OPTION.getId();
 			default:
 				throw new IllegalArgumentException("action = " + action);
 		}

--- a/runescape-client/src/main/java/RuneLiteMenuEntry.java
+++ b/runescape-client/src/main/java/RuneLiteMenuEntry.java
@@ -377,7 +377,7 @@ public class RuneLiteMenuEntry implements MenuEntry {
 		Player[] players = client.getCachedPlayers();
 		Player player = null;
 		MenuAction menuAction = this.getType();
-		if (menuAction == MenuAction.PLAYER_FIRST_OPTION || menuAction == MenuAction.PLAYER_SECOND_OPTION || menuAction == MenuAction.PLAYER_THIRD_OPTION || menuAction == MenuAction.PLAYER_FOURTH_OPTION || menuAction == MenuAction.PLAYER_FIFTH_OPTION || menuAction == MenuAction.PLAYER_SIXTH_OPTION || menuAction == MenuAction.PLAYER_SEVENTH_OPTION || menuAction == MenuAction.PLAYER_EIGTH_OPTION || menuAction == MenuAction.WIDGET_TARGET_ON_PLAYER || menuAction == MenuAction.RUNELITE_PLAYER) {
+		if (menuAction == MenuAction.PLAYER_FIRST_OPTION || menuAction == MenuAction.PLAYER_SECOND_OPTION || menuAction == MenuAction.PLAYER_THIRD_OPTION || menuAction == MenuAction.PLAYER_FOURTH_OPTION || menuAction == MenuAction.PLAYER_FIFTH_OPTION || menuAction == MenuAction.PLAYER_SIXTH_OPTION || menuAction == MenuAction.PLAYER_SEVENTH_OPTION || menuAction == MenuAction.PLAYER_EIGHTH_OPTION || menuAction == MenuAction.WIDGET_TARGET_ON_PLAYER || menuAction == MenuAction.RUNELITE_PLAYER) {
 			int identifier = this.getIdentifier();
 			if (identifier >= 0 && identifier < players.length) {
 				player = players[identifier];


### PR DESCRIPTION
Replace EIGTH with correct spelling EIGHTH and leave the incorrect field annotated with deprecated for older plugins to call so we do not have to update those plugins