### PR TITLE
Fix WorldArea constructor to be inclusive

### DIFF
--- a/runelite-api/src/main/java/net/runelite/api/coords/WorldArea.java
+++ b/runelite-api/src/main/java/net/runelite/api/coords/WorldArea.java
@@ -95,8 +95,8 @@ public class WorldArea
 		this.x = swLocation.getX();
 		this.y = swLocation.getY();
 		this.plane = swLocation.getPlane();
-		this.width = neLocation.getX() - swLocation.getX();
-		this.height = neLocation.getY() - swLocation.getY();
+		this.width = neLocation.getX() - swLocation.getX() + 1;
+		this.height = neLocation.getY() - swLocation.getY() + 1;
 	}
 
 	/**


### PR DESCRIPTION
WorldArea constructor with two WorldPoints excludes the boundary created by the second point for some reason. For consistency this should be inclusive.