### PR TITLE
Update RSClientMixin.java

### DIFF
--- a/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
+++ b/runelite-mixins/src/main/java/net/runelite/mixins/RSClientMixin.java
@@ -1903,11 +1903,6 @@ public abstract class RSClientMixin implements RSClient
 		{
 			MenuEntry tmpEntry = client.createMenuEntry(option, target, id, opcode, param0, param1, false);
 			event = new MenuOptionClicked(tmpEntry);
-
-			if (canvasX != -1 || canvasY != -1)
-			{
-				client.getLogger().warn("Unable to find clicked menu op {} targ {} action {} id {} p0 {} p1 {}", option, target, opcode, id, param0, param1);
-			}
 		}
 		else
 		{


### PR DESCRIPTION
removed warning being triggered after every mouse click invoke

if the warning is still necessary:
 only raise the warning if we aren't using click packets 