### PR TITLE
RSNPCComposition: change wrongly named isClickable to isClipped

### DIFF
--- a/runescape-api/src/main/java/net/runelite/rs/api/RSNPCComposition.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSNPCComposition.java
@@ -18,8 +18,8 @@ public interface RSNPCComposition extends NPCComposition
 	@Override
 	String[] getActions();
 
-	@Import("isClickable")
-	boolean isClickable();
+	@Import("isClipped")
+	boolean isClipped();
 
 	@Import("isFollower")
 	@Override

--- a/runescape-client/src/main/java/NPCComposition.java
+++ b/runescape-client/src/main/java/NPCComposition.java
@@ -208,8 +208,8 @@ public class NPCComposition extends DualNode {
 	@Export("isInteractable")
 	public boolean isInteractable;
 	@ObfuscatedName("bu")
-	@Export("isClickable")
-	public boolean isClickable;
+	@Export("isClipped")
+	public boolean isClipped;
 	@ObfuscatedName("bf")
 	@Export("isFollower")
 	public boolean isFollower;
@@ -261,7 +261,7 @@ public class NPCComposition extends DualNode {
 		this.transformVarbit = -1;
 		this.transformVarp = -1;
 		this.isInteractable = true;
-		this.isClickable = true;
+		this.isClipped = true;
 		this.isFollower = false;
 		this.headIconArchiveIds = null;
 		this.headIconSpriteIndex = null;
@@ -400,7 +400,7 @@ public class NPCComposition extends DualNode {
 				if (var2 == 107) {
 					this.isInteractable = false;
 				} else if (var2 == 109) {
-					this.isClickable = false;
+					this.isClipped = false;
 				} else if (var2 == 111) {
 					this.isFollower = true;
 				} else if (var2 == 114) {

--- a/runescape-client/src/main/java/class6.java
+++ b/runescape-client/src/main/java/class6.java
@@ -129,7 +129,7 @@ public enum class6 implements MouseWheel {
 						int var9 = 4;
 						boolean var10 = true;
 						if (var0 instanceof NPC) {
-							var10 = ((NPC)var0).definition.isClickable;
+							var10 = ((NPC)var0).definition.isClipped;
 						}
 
 						if (var10) {


### PR DESCRIPTION
This is mainly used for Implings (maybe some more npcs?) since they can move over water and lava, teleport and have a large area movement but cannot move over obstacles that can be labelled with a line on the minimap

See wiki: https://oldschool.runescape.wiki/w/Impling

This is an addition to commits: b409a8d42a0fded7677c3dee5396e5cee813a2ef b9d9140cab6b5092e9a0a5c7e0ed03c98ad9b325