### PR TITLE
Cached random.dat

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/RuneLite.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLite.java
@@ -217,6 +217,8 @@ public class RuneLite
 
 		final OptionSpec<Void> insecureWriteCredentials = parser.accepts("insecure-write-credentials", "Dump authentication tokens from the Jagex Launcher to a text file to be used for development");
 
+		final OptionSpec<Void> cachedRandomDat = parser.accepts("cached-random-dat", "Use cached random.dat data for each account");
+
 		parser.accepts("help", "Show this text").forHelp();
 		OptionSet options = SettingsManager.parseArgs(parser, args);
 
@@ -320,7 +322,8 @@ public class RuneLite
 				options.valueOf(sessionfile),
 				options.valueOf(configfile),
 				options,
-				options.has(insecureWriteCredentials)
+				options.has(insecureWriteCredentials),
+				options.has(cachedRandomDat)
 			));
 
 			injector.getInstance(RuneLite.class).start(options);

--- a/runelite-client/src/main/java/net/runelite/client/RuneLiteModule.java
+++ b/runelite-client/src/main/java/net/runelite/client/RuneLiteModule.java
@@ -89,6 +89,7 @@ public class RuneLiteModule extends AbstractModule
 	private final File config;
 	private final OptionSet optionSet;
 	private final boolean insecureWriteCredentials;
+	private final boolean cachedRandomDat;
 
 	@Override
 	protected void configure()
@@ -136,6 +137,7 @@ public class RuneLiteModule extends AbstractModule
 		bind(File.class).annotatedWith(Names.named("sessionfile")).toInstance(sessionfile);
 		bind(File.class).annotatedWith(Names.named("config")).toInstance(config);
 		bindConstant().annotatedWith(Names.named("insecureWriteCredentials")).to(insecureWriteCredentials);
+		bindConstant().annotatedWith(Names.named("cachedRandomDat")).to(cachedRandomDat);
 		bind(File.class).annotatedWith(Names.named("runeLiteDir")).toInstance(RuneLite.RUNELITE_DIR);
 		bind(ScheduledExecutorService.class).toInstance(new ExecutorServiceExceptionLogger(Executors.newSingleThreadScheduledExecutor()));
 		bind(OkHttpClient.class).toInstance(okHttpClient);

--- a/runelite-client/src/main/java/net/unethicalite/client/minimal/MinimalClient.java
+++ b/runelite-client/src/main/java/net/unethicalite/client/minimal/MinimalClient.java
@@ -223,6 +223,8 @@ public class MinimalClient
 
 		final OptionSpec<Void> insecureWriteCredentials = parser.accepts("insecure-write-credentials", "Dump authentication tokens from the Jagex Launcher to a text file to be used for development");
 
+		final OptionSpec<Void> cachedRandomDat = parser.accepts("cached-random-dat", "Use cached random.dat data for each account");
+
 		Thread.setDefaultUncaughtExceptionHandler((thread, throwable) ->
 		{
 			log.error("Uncaught exception:", throwable);
@@ -264,7 +266,8 @@ public class MinimalClient
 					clientLoader,
 					options.valueOf(configfile),
 					options,
-				        options.has(insecureWriteCredentials)
+					options.has(insecureWriteCredentials),
+					options.has(cachedRandomDat)
 			)));
 
 			RuneLite.getInjector().getInstance(MinimalClient.class).start(options);

--- a/runelite-client/src/main/java/net/unethicalite/client/minimal/MinimalModule.java
+++ b/runelite-client/src/main/java/net/unethicalite/client/minimal/MinimalModule.java
@@ -59,6 +59,7 @@ public class MinimalModule extends AbstractModule
 	private final File config;
 	private final OptionSet optionSet;
 	private final boolean insecureWriteCredentials;
+	private final boolean cachedRandomDat;
 
 	@Override
 	protected void configure()
@@ -75,6 +76,7 @@ public class MinimalModule extends AbstractModule
 		bindConstant().annotatedWith(Names.named("safeMode")).to(false);
 		bind(File.class).annotatedWith(Names.named("config")).toInstance(config);
 		bindConstant().annotatedWith(Names.named("insecureWriteCredentials")).to(insecureWriteCredentials);
+		bindConstant().annotatedWith(Names.named("cachedRandomDat")).to(cachedRandomDat);
 		bind(File.class).annotatedWith(Names.named("runeLiteDir")).toInstance(RuneLite.RUNELITE_DIR);
 		bind(ScheduledExecutorService.class).toInstance(new ExecutorServiceExceptionLogger(Executors.newSingleThreadScheduledExecutor()));
 		bind(OkHttpClient.class).toInstance(okHttpClient);

--- a/runelite-mixins/src/main/java/net/devious/mixins/DRSCachedRandomDatMixin.java
+++ b/runelite-mixins/src/main/java/net/devious/mixins/DRSCachedRandomDatMixin.java
@@ -1,0 +1,150 @@
+package net.devious.mixins;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Properties;
+import net.runelite.api.mixins.Copy;
+import net.runelite.api.mixins.Inject;
+import net.runelite.api.mixins.MethodHook;
+import net.runelite.api.mixins.Mixin;
+import net.runelite.api.mixins.Replace;
+import net.runelite.api.mixins.Shadow;
+import net.runelite.rs.api.RSClient;
+
+@Mixin(RSClient.class)
+public abstract class DRSCachedRandomDatMixin implements RSClient
+{
+	@Shadow("client")
+	private static RSClient client;
+
+	@net.runelite.api.mixins.Inject
+	@javax.inject.Inject
+	@javax.inject.Named("cachedRandomDat")
+	private boolean cachedRandomDat;
+
+	@Inject
+	@Override
+	public boolean useCachedRandomDat()
+	{
+		return cachedRandomDat;
+	}
+
+	@net.runelite.api.mixins.Inject
+	@javax.inject.Inject
+	@javax.inject.Named("runeLiteDir")
+	private File openosrsDir;
+
+	@Inject
+	private File cachedDataFile;
+
+	@Inject
+	private Properties cachedDataProperties;
+
+	@Inject
+	@Override
+	public byte[] getCachedRandomDatData(String username)
+	{
+		if (cachedDataProperties == null)
+		{
+			cachedDataFile = new File(openosrsDir, "random.dat-cached.properties");
+			cachedDataProperties = new Properties();
+
+			if (cachedDataProperties.isEmpty() && cachedDataFile.exists())
+			{
+				try (InputStreamReader inputStreamReader = new InputStreamReader(new FileInputStream(cachedDataFile), StandardCharsets.UTF_8))
+				{
+					cachedDataProperties.load(inputStreamReader);
+				}
+				catch (IOException e)
+				{
+					client.getLogger().warn("Unable to load cached random.dat profiles from disk", e);
+				}
+
+				if (cachedDataProperties.size() > 0)
+				{
+					client.getLogger().info("Read {} cached random.dat profiles from disk", cachedDataProperties.size());
+				}
+			}
+		}
+
+		byte[] data = null;
+		String property = cachedDataProperties.getProperty(username);
+		if (property != null)
+		{
+			data = Base64.getDecoder().decode(property);
+		}
+		return data != null ? data : null;
+	}
+
+	@Inject
+	@Override
+	public void writeCachedRandomDatData(String username, byte[] data)
+	{
+		cachedDataProperties.setProperty(username, Base64.getEncoder().encodeToString(data));
+		try (OutputStreamWriter outputStreamWriter = new OutputStreamWriter(Files.newOutputStream(cachedDataFile.toPath()), StandardCharsets.UTF_8))
+		{
+			cachedDataProperties.store(outputStreamWriter, "Cached random.dat");
+		}
+		catch (IOException e)
+		{
+			client.getLogger().warn("Unable to write cached random.dat to disk", e);
+		}
+	}
+
+	@Inject
+	@MethodHook(value = "writeRandomDat", end = true)
+	public static void onWriteNewRandomDatData(byte[] var0, int var1, byte[] newRandomDatData, int var3, int var4)
+	{
+		if (!client.useCachedRandomDat())
+		{
+			return;
+		}
+
+		client.getLogger().info("Saving new random.dat data {} for user {}", newRandomDatData, client.getUsername());
+		client.writeCachedRandomDatData(client.getUsername(), newRandomDatData);
+	}
+
+	@Copy("randomDatData2")
+	@Replace("randomDatData2")
+	public static byte[] copy$RandomDatData2()
+	{
+		if (!client.useCachedRandomDat())
+		{
+			return copy$RandomDatData2();
+		}
+
+		byte[] loadedData = copy$RandomDatData2();
+		client.getLogger().info("Loaded random.dat data {} for user {}", loadedData, client.getUsername());
+
+		byte[] cachedData = client.getCachedRandomDatData(client.getUsername());
+		if (cachedData != null)
+		{
+			client.getLogger().info("Loaded cached data {} for user {}", cachedData, client.getUsername());
+			if (!Arrays.equals(cachedData, loadedData))
+			{
+				client.getLogger().info("Using cached random.dat data {} for user {}", cachedData, client.getUsername());
+				return cachedData;
+			}
+		}
+		else
+		{
+			byte[] emptyData = new byte[24];
+			for (byte i = 0; i < 24; i++)
+			{
+				emptyData[i] = -1;
+			}
+			client.getLogger().info("Using empty random.dat data {} for user {}", emptyData, client.getUsername());
+			return emptyData;
+		}
+
+		client.getLogger().info("Using default random.dat data {} for user {} (Cached random.dat data matches random.dat file)", loadedData, client.getUsername());
+		return loadedData;
+	}
+}

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -1846,4 +1846,12 @@ public interface RSClient extends RSGameEngine, Client
 	java.util.Properties getCredentialsProperties();
 	boolean storeCredentials();
 	void writeCredentials();
+
+	/**
+	 * Cached random.dat
+	 */
+
+	byte[] getCachedRandomDatData(String username);
+	void writeCachedRandomDatData(String username, byte[] data);
+	boolean useCachedRandomDat();
 }

--- a/runescape-client/src/main/java/Client.java
+++ b/runescape-client/src/main/java/Client.java
@@ -2538,7 +2538,7 @@ public final class Client extends GameEngine implements Usernamed, OAuthApi, cla
 				if (randomDatData != null) {
 					var9.writeBytes(randomDatData, 0, randomDatData.length);
 				} else {
-					byte[] var10 = class131.method3015();
+					byte[] var10 = class131.randomDatData2();
 					var9.writeBytes(var10, 0, var10.length);
 				}
 

--- a/runescape-client/src/main/java/PlatformInfo.java
+++ b/runescape-client/src/main/java/PlatformInfo.java
@@ -14,8 +14,8 @@ public class PlatformInfo extends Node {
 	@Export("os")
 	int os;
 	@ObfuscatedName("bz")
-	@Export("field4518")
-	boolean field4518;
+	@Export("arch64")
+	boolean arch64;
 	@ObfuscatedName("bb")
 	@ObfuscatedGetter(
 		intValue = 1658886897
@@ -134,7 +134,7 @@ public class PlatformInfo extends Node {
 	PlatformInfo(int var1, boolean var2, int var3, int var4, int var5, int var6, int var7, boolean var8, int var9, int var10, int var11, int var12, String var13, String var14, String var15, String var16, int var17, int var18, int var19, int var20, String var21, String var22, int[] var23, int var24, String var25, String var26) {
 		this.field4539 = new int[3];
 		this.os = var1;
-		this.field4518 = var2;
+		this.arch64 = var2;
 		this.osVersion = var3;
 		this.vendor = var4;
 		this.javaMajor = var5;
@@ -170,7 +170,7 @@ public class PlatformInfo extends Node {
 	public void write(Buffer var1) {
 		var1.writeByte(9);
 		var1.writeByte(this.os);
-		var1.writeByte(this.field4518 ? 1 : 0);
+		var1.writeByte(this.arch64 ? 1 : 0);
 		var1.writeShort(this.osVersion);
 		var1.writeByte(this.vendor);
 		var1.writeByte(this.javaMajor);

--- a/runescape-client/src/main/java/class131.java
+++ b/runescape-client/src/main/java/class131.java
@@ -1,5 +1,6 @@
 import java.io.IOException;
 import java.util.concurrent.Callable;
+import net.runelite.mapping.Export;
 import net.runelite.mapping.ObfuscatedGetter;
 import net.runelite.mapping.ObfuscatedName;
 import net.runelite.mapping.ObfuscatedSignature;
@@ -66,7 +67,8 @@ public class class131 implements Callable {
 		descriptor = "(B)[B",
 		garbageValue = "1"
 	)
-	public static byte[] method3015() {
+	@Export("randomDatData2")
+	public static byte[] randomDatData2() {
 		byte[] var0 = new byte[24];
 
 		try {

--- a/runescape-client/src/main/java/class178.java
+++ b/runescape-client/src/main/java/class178.java
@@ -82,7 +82,7 @@ public class class178 {
 		if (Client.randomDatData != null) {
 			var5.writeBytes(Client.randomDatData, 0, Client.randomDatData.length);
 		} else {
-			byte[] var16 = class131.method3015();
+			byte[] var16 = class131.randomDatData2();
 			var5.writeBytes(var16, 0, var16.length);
 		}
 


### PR DESCRIPTION
This will save and use the cached random.dat data for each account when it is enabled. If the account is not cached yet it will use the 24 bytes -1 which is the same as vanilla and store the new bytes for you, this automatically happens when the 24 bytes are set to -1. After a client reload and if cached random.dat is enabled with client args: --cached-random-dat it will use the cached data for your account