### PR TITLE
rs-client: fix a JSONObject method mapping

### DIFF
--- a/runescape-client/src/main/java/org/json/JSONObject.java
+++ b/runescape-client/src/main/java/org/json/JSONObject.java
@@ -1,5 +1,6 @@
 package org.json;
 
+import net.runelite.mapping.Export;
 import net.runelite.rs.Reflection;
 
 import java.io.IOException;
@@ -103,6 +104,7 @@ public class JSONObject {
       }
    }
 
+   @Export("method8392")
    public JSONObject method8392(String var1, Object var2) throws JSONException {
       if (var1 == null) {
          throw new JSONException("Null key.");


### PR DESCRIPTION
Just copy over the org/json files when doing a revision update without having to fix the method name or null object every time