### PR TITLE
unethicalite: Changed ItemContainer caching to use `ItemContainerSnapshot` instead of an `Item[]` as value

### DIFF
--- a/runelite-client/src/main/java/net/unethicalite/api/items/Inventory.java
+++ b/runelite-client/src/main/java/net/unethicalite/api/items/Inventory.java
@@ -70,13 +70,15 @@ public class Inventory extends Items
 
 	public static Item getItem(int slot)
 	{
-		Item[] container = InventoryManager.getCachedContainers().get(InventoryID.INVENTORY.getId());
-		if (container == null)
+		ItemContainerSnapshot containerSnapshot = InventoryManager.getCachedContainers().get(InventoryID.INVENTORY.getId());
+		if (containerSnapshot == null)
 		{
 			return null;
 		}
 
-		Item item = container[slot];
+		Item[] items = containerSnapshot.getItems();
+
+		Item item = items[slot];
 		if (item == null || item.getId() == -1 || item.getName() == null || item.getName().equals("null"))
 		{
 			return null;

--- a/runelite-client/src/main/java/net/unethicalite/api/items/ItemContainerSnapshot.java
+++ b/runelite-client/src/main/java/net/unethicalite/api/items/ItemContainerSnapshot.java
@@ -1,0 +1,35 @@
+package net.unethicalite.api.items;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import java.time.Instant;
+import net.runelite.api.Item;
+import net.runelite.api.events.ItemContainerChanged;
+
+@Getter
+@RequiredArgsConstructor
+public class ItemContainerSnapshot
+{
+    /**
+     * ID of the container the snapshot was taken of.
+     */
+    private final int containerId;
+
+    /**
+     * Items within the inventory at the given snapshot.
+     */
+    private final Item[] items;
+
+    /**
+     * Snapshot creation timestamp.
+     */
+    private final Instant timestamp;
+
+    public ItemContainerSnapshot(ItemContainerChanged event)
+    {
+        this.containerId = event.getContainerId();
+        this.items = event.getItemContainer().getItems();
+        this.timestamp = Instant.now();
+    }
+
+}

--- a/runelite-client/src/main/java/net/unethicalite/client/managers/InventoryManager.java
+++ b/runelite-client/src/main/java/net/unethicalite/client/managers/InventoryManager.java
@@ -1,23 +1,22 @@
 package net.unethicalite.client.managers;
 
 import lombok.Getter;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.inject.Inject;
+import javax.inject.Singleton;
 import net.runelite.api.Client;
 import net.runelite.api.InventoryID;
-import net.runelite.api.Item;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
+import net.unethicalite.api.items.ItemContainerSnapshot;
 
 @Singleton
 public class InventoryManager
 {
 	@Getter
-	private static final Map<Integer, Item[]> cachedContainers = new ConcurrentHashMap<>();
+	private static final Map<Integer, ItemContainerSnapshot> cachedContainers = new ConcurrentHashMap<>();
 
 	@Inject
 	private Client client;
@@ -31,11 +30,15 @@ public class InventoryManager
 	@Subscribe(priority = Integer.MAX_VALUE)
 	private void onItemContainerChanged(ItemContainerChanged e)
 	{
-		cachedContainers.put(e.getContainerId(), e.getItemContainer().getItems());
+		ItemContainerSnapshot items = new ItemContainerSnapshot(e);
+		cachedContainers.put(e.getContainerId(), items);
+
 		if (e.getContainerId() == InventoryID.INVENTORY.getId())
 		{
 			// Reload inventory
 			client.runScript(6009, 9764864, 28, 1, -1);
 		}
 	}
+
+
 }


### PR DESCRIPTION
This extends the inventory snapshot with additional information such as `timestamp`
Also makes it extendable in the future if needed.