### PR TITLE
runelite-client: Allow access by reflection to java.lang.reflect=ALL-UNNAMED

### DIFF
--- a/runelite-client/runelite-client.gradle.kts
+++ b/runelite-client/runelite-client.gradle.kts
@@ -209,5 +209,6 @@ tasks {
         classpath = project.sourceSets.main.get().runtimeClasspath
         enableAssertions = true
         mainClass.set("net.unethicalite.client.Unethicalite")
+        jvmArgs("--add-opens=java.base/java.lang.reflect=ALL-UNNAMED")
     }
 }


### PR DESCRIPTION

[Strong Encapsulation in the JDK](https://docs.oracle.com/en/java/javase/17/migrate/migrating-jdk-8-later-jdk-releases.html#GUID-7BB28E4D-99B3-4078-BDC4-FC24180CE82B)