### PR TITLE
unethicalite: Migrate from jcenter repository

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ import org.ajoberstar.grgit.Grgit
 buildscript {
     repositories {
         mavenLocal()
-        gradlePluginPortal()
+        mavenCentral()
         maven(url = "https://repo.runelite.net")
         maven(url = "https://raw.githubusercontent.com/jbx5/hosting/master")
         maven(url = "https://raw.githubusercontent.com/jbx5/devious-hosting/master")


### PR DESCRIPTION
Gradle plugin portal is a jcenter mirror.
[JCenter Shutdown Impact on Gradle Builds](https://blog.gradle.org/jcenter-shutdown)