### PR TITLE
mixins: fix --cached-uuid arg guice

### DIFF
--- a/runelite-mixins/src/main/java/net/devious/mixins/DRSCachedDeviceIdGuiceMixin.java
+++ b/runelite-mixins/src/main/java/net/devious/mixins/DRSCachedDeviceIdGuiceMixin.java
@@ -1,0 +1,21 @@
+package net.devious.mixins;
+
+import net.runelite.api.mixins.Inject;
+import net.runelite.api.mixins.Mixin;
+import net.runelite.rs.api.RSClient;
+
+@Mixin(RSClient.class)
+public abstract class DRSCachedDeviceIdGuiceMixin implements RSClient
+{
+	@Inject
+	@javax.inject.Inject
+	@javax.inject.Named("cachedUUID")
+	private boolean cachedUUID;
+
+	@Inject
+	@Override
+	public boolean useCachedUUID()
+	{
+		return cachedUUID;
+	}
+}

--- a/runelite-mixins/src/main/java/net/devious/mixins/DRSCachedDeviceIdMixin.java
+++ b/runelite-mixins/src/main/java/net/devious/mixins/DRSCachedDeviceIdMixin.java
@@ -9,6 +9,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Properties;
 import java.util.UUID;
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
 import net.runelite.api.mixins.Copy;
 import net.runelite.api.mixins.Inject;
 import net.runelite.api.mixins.Mixin;
@@ -23,16 +25,6 @@ public abstract class DRSCachedDeviceIdMixin implements RSPlatformInfo
 	@Shadow("client")
 	private static RSClient client;
 
-	@net.runelite.api.mixins.Inject
-	@javax.inject.Inject
-	@javax.inject.Named("cachedUUID")
-	private boolean cachedUUID; // Does not work
-
-	@net.runelite.api.mixins.Inject
-	@javax.inject.Inject
-	@javax.inject.Named("runeLiteDir")
-	private File oprsDir; // Does not work
-
 	@Inject
 	private File cachedUUIDFile;
 
@@ -43,12 +35,16 @@ public abstract class DRSCachedDeviceIdMixin implements RSPlatformInfo
 	@Replace("getDeviceId")
 	public String copy$getDeviceId(int os)
 	{
-		/*if (!cachedUUID)
+		if (!client.useCachedUUID())
 		{
-			String deviceId = copy$getDeviceId(os);
-			client.getLogger().warn("Found deviceId (UUID): {}", deviceId);
-			return deviceId;
-		}*/
+			int option = JOptionPane.showConfirmDialog(new JFrame(), "Do you want to use cached random uuid?", "UUID request", JOptionPane.YES_NO_OPTION);
+			if (option == JOptionPane.NO_OPTION)
+			{
+				String deviceId = copy$getDeviceId(os);
+				client.getLogger().warn("Found deviceId (UUID): {}", deviceId);
+				return deviceId;
+			}
+		}
 
 		String cachedDeviceId = getCachedUUID(client.getUsername());
 		if (cachedDeviceId == null)

--- a/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
+++ b/runescape-api/src/main/java/net/runelite/rs/api/RSClient.java
@@ -1880,4 +1880,10 @@ public interface RSClient extends RSGameEngine, Client
 	byte[] getCachedRandomDatData(String username);
 	void writeCachedRandomDatData(String username, byte[] data);
 	boolean useCachedRandomDat();
+
+	/**
+	 * Cached UUID
+	 */
+
+	boolean useCachedUUID();
 }


### PR DESCRIPTION
49246edc2781dcb121f36d3132acb26c1f62e0ee

This should be used together with `--cached-random-dat` since it could be another way to identify the same computer for jagex

It could be that jagex only uses the uuid to verify if the jagex launcher and client are on the same computer. Time will tell if that is the case when using the cached uuid