### PR TITLE
project: Bump injector version

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,7 @@ buildscript {
     dependencies {
         classpath("org.ajoberstar.grgit:grgit-core:4.1.0")
         classpath("com.openosrs:script-assembler-plugin:1.0.2")
-        classpath("com.openosrs:injector-plugin:2.0.22")
+        classpath("com.openosrs:injector-plugin:2.0.23")
         classpath("com.openosrs:interface-parser-plugin:1.0.1")
     }
 }


### PR DESCRIPTION
- JagexLauncherCredentials update rev 221

This requires: [https://github.com/jbx5/hosting/pull/6](https://github.com/jbx5/hosting/pull/6) [https://github.com/jbx5/devious-injector/pull/6](https://github.com/jbx5/devious-injector/pull/6)