### PR TITLE
Fix event bus setting wrong parameter index.

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/eventbus/EventBus.java
+++ b/runelite-client/src/main/java/net/runelite/client/eventbus/EventBus.java
@@ -143,7 +143,7 @@ public class EventBus
 						caller,
 						"accept",
 						MethodType.methodType(Consumer.class, clazz),
-						subscription.changeParameterType(0, Object.class),
+						subscription.changeParameterType(method.getModifiers() & Modifier.STATIC, Object.class),
 						target,
 						subscription);
 


### PR DESCRIPTION
This is just a small change to stop some bugs that were arising from plugins having both static and non static event subscribers.