### PR TITLE
movement: Add option to temporarily disable teleports and transports

### DIFF
--- a/runelite-client/src/main/java/net/unethicalite/api/movement/Movement.java
+++ b/runelite-client/src/main/java/net/unethicalite/api/movement/Movement.java
@@ -110,6 +110,16 @@ public class Movement
 		return Walker.walkTo(worldArea);
 	}
 
+	public static boolean walkTo(WorldArea worldArea, boolean disableTeleports)
+	{
+		return Walker.walkTo(worldArea, disableTeleports);
+	}
+
+	public static boolean walkTo(WorldArea worldArea, boolean disableTeleports, boolean disableTransports)
+	{
+		return Walker.walkTo(worldArea, disableTeleports, disableTransports);
+	}
+
 	public static void walk(Locatable locatable)
 	{
 		walk(locatable.getWorldLocation());
@@ -120,6 +130,15 @@ public class Movement
 		return Walker.walkTo(worldPoint);
 	}
 
+	public static boolean walkTo(WorldPoint worldPoint, boolean disableTeleports)
+	{
+		return Walker.walkTo(worldPoint, disableTeleports);
+	}
+
+	public static boolean walkTo(WorldPoint worldPoint, boolean disableTeleports, boolean disableTransports)
+	{
+		return Walker.walkTo(worldPoint, disableTeleports, disableTransports);
+	}
 
 	public static boolean walkTo(Locatable locatable)
 	{

--- a/runelite-client/src/main/java/net/unethicalite/api/movement/pathfinder/Walker.java
+++ b/runelite-client/src/main/java/net/unethicalite/api/movement/pathfinder/Walker.java
@@ -58,14 +58,39 @@ public class Walker
     private static final ExecutorService executor = Executors.newSingleThreadExecutor();
     private static Future<List<WorldPoint>> pathFuture = null;
     private static WorldArea currentDestination = null;
+    private static boolean disableTeleports;
+    private static boolean disableTransports;
 
     public static boolean walkTo(WorldPoint destination)
     {
-        return walkTo(destination.toWorldArea());
+        return walkTo(destination, false);
+    }
+
+    public static boolean walkTo(WorldPoint destination, boolean disableTeleports)
+    {
+        return walkTo(destination, disableTeleports, false);
+    }
+
+    public static boolean walkTo(WorldPoint destination, boolean disableTeleports, boolean disableTransports)
+    {
+        return walkTo(destination.toWorldArea(), disableTeleports, disableTransports);
     }
 
     public static boolean walkTo(WorldArea destination)
     {
+        return walkTo(destination, false);
+    }
+
+    public static boolean walkTo(WorldArea destination, boolean disableTeleports)
+    {
+        return walkTo(destination, disableTeleports, false);
+    }
+
+    public static boolean walkTo(WorldArea destination, boolean disableTeleports, boolean disableTransports)
+    {
+        Walker.disableTeleports = disableTeleports;
+        Walker.disableTransports = disableTransports;
+
         Player local = Players.getLocal();
         if (destination.contains(local))
         {
@@ -553,7 +578,7 @@ public class Walker
     public static Map<WorldPoint, List<Transport>> buildTransportLinks()
     {
         Map<WorldPoint, List<Transport>> out = new HashMap<>();
-        if (!Static.getUnethicaliteConfig().useTransports())
+        if (!Static.getUnethicaliteConfig().useTransports() || disableTransports)
         {
             return out;
         }
@@ -569,7 +594,7 @@ public class Walker
     public static LinkedHashMap<WorldPoint, Teleport> buildTeleportLinks(WorldArea destination)
     {
         LinkedHashMap<WorldPoint, Teleport> out = new LinkedHashMap<>();
-        if (!Static.getUnethicaliteConfig().useTeleports())
+        if (!Static.getUnethicaliteConfig().useTeleports() || disableTeleports)
         {
             return out;
         }


### PR DESCRIPTION
These overloads allow plugins to temporarily disable teleports and/or transports during pathfinding without the user having to disable en re-enable them in the Unethicalite configuration panel. The default behavior of these methods is the same as before so as to not break any existing plugins.